### PR TITLE
Fixed "Author" key returning none

### DIFF
--- a/src/simpledas/__init__.py
+++ b/src/simpledas/__init__.py
@@ -10,6 +10,6 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "unknown"
 
 try:
-    __author__ = importlib.metadata.author(__name__)
-except:
+    __author__ = importlib.metadata.metadata(__name__)["Author"]
+except (importlib.metadata.PackageNotFoundError, KeyError):
     __author__ = "Ole Henrik Waagaard"

--- a/src/simpledas/__init__.py
+++ b/src/simpledas/__init__.py
@@ -3,5 +3,13 @@ from . import h5pydict
 import importlib.metadata
 
 __all__ = ['simpleDASreader', 'h5pydict']
-__version__ = importlib.metadata.version(__name__)
-__author__ = importlib.metadata.metadata('simpledas')['Author']
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+try:
+    __author__ = importlib.metadata.get('Author', 'Ole Henrik Waagaard')
+except (importlib.metadata.PackageNotFoundError, KeyError):
+    __author__ = "unknown"

--- a/src/simpledas/__init__.py
+++ b/src/simpledas/__init__.py
@@ -10,6 +10,6 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "unknown"
 
 try:
-    __author__ = importlib.metadata.metadata(__name__)["Authors"]
+    __author__ = importlib.metadata.metadata(__name__)["Author-email"]
 except (importlib.metadata.PackageNotFoundError, KeyError):
     __author__ = "Ole Henrik Waagaard"

--- a/src/simpledas/__init__.py
+++ b/src/simpledas/__init__.py
@@ -10,6 +10,6 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "unknown"
 
 try:
-    __author__ = importlib.metadata.metadata(__name__)["Author"]
+    __author__ = importlib.metadata.metadata(__name__)["Authors"]
 except (importlib.metadata.PackageNotFoundError, KeyError):
     __author__ = "Ole Henrik Waagaard"

--- a/src/simpledas/__init__.py
+++ b/src/simpledas/__init__.py
@@ -10,6 +10,6 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "unknown"
 
 try:
-    __author__ = importlib.metadata.get('Author', 'Ole Henrik Waagaard')
-except (importlib.metadata.PackageNotFoundError, KeyError):
-    __author__ = "unknown"
+    __author__ = importlib.metadata.author(__name__)
+except:
+    __author__ = "Ole Henrik Waagaard"


### PR DESCRIPTION
Since the email of the author is entered in the author's list in the `pyproject.toml`, the right key to use now is "Author-email". The former produced warnings and errors when importing the package. 